### PR TITLE
Multiple SSO Identity Providers

### DIFF
--- a/sso/cognito/README.md
+++ b/sso/cognito/README.md
@@ -1,0 +1,103 @@
+# SSO Azure AD Setup Script
+
+This script is designed to run on a mac. It will likely not run on a linux bash terminal and will certainly not run on windows.
+
+In particular it uses `pbcopy` and `open` as commands to cause data to be written to the clipboard and websites to be opened.
+
+## Default Values
+
+Default values are set at the top of the script.
+
+## AWS Params
+
+### Profile
+
+There is an assumption that multiple profiles are set up in a file in the standard `~/.aws/credentials` file. These are printed out for information purposes and any value can then be entered.
+
+The profile is not passed to each command using `--profile` instead `AWS_PROFILE` is exported.
+
+### Region
+
+The region is not passed in with each command. The region for commands will come from the profile. The value requested is only used to specify which region the cognito pool will be 
+placed in.
+
+## Cognoto Values
+
+### Company Identifier
+
+This will be used to create names which will be unique across aws. It will also be used as the prefix for creating other identifiers used elsewhere. Consequently a reverse domain but
+with hyphens instead of dots (dots are not supported).
+
+### App Name
+
+This is a name for the application that you are building. 
+
+### Env Name
+
+As it is assumed the script may be used to create multiple applications in multiple environments. Standard values would be `dev`, `test` and `prod` etc.
+
+### Mantissa
+
+As this script is expected to be used to get to grips with how this all works one might end up running everything multiple times. It is unlikely to be used more than once per minute and so the minute timestamp seemed appropriate. When making in prod or finally once happy with everything one would likely not want a mantissa, so if `NONE` is specified it works without adding the mantissa or the trailing `-`.
+
+### Identifier
+
+The identifier is used as the name of the application in azure and as the default name for the app in Azure and as a prefix for the default names of the user pool, client and provider name.
+
+## Cognito Actions
+
+### Create a User Pool
+
+Users need to be placed inside a user pool. We will need to get the pool id from the output.
+
+### Creata a User Pool Domain
+
+Not really sure what this does.
+
+### Create Custom Attribute for the Azure Groups.
+
+As we are going to receive some groups from Azure we need a place to put them. This custom attribute goes inside the user pool. Custom attributes have the name `custom:` as a prefix.
+
+## Azure Actions
+
+A number of steps will be set up in Azure. Follow the instructions in the script. Nothing is very exciting. From time to time there maybe an extra dialog or similar that needs closing.
+
+It is supposedly possible to set up Azure to allow multiple azure instances to be part of an Enterprise application. However, this does not seem to work as the `urn` protocol is not supported in that scenario.
+
+### Create an identity provider. 
+
+Identity providers can be set up to support only users that meet some criteria. This can be either a whole email address or else a domain from an email address. 
+
+Multiple identity providers can be registered to a user pool.
+
+If multiple Azure AD need to be set up this is the way to do it, by adding multiple identity providers. Which users they will work for can be controlled using the `--idp-identifiers` flag. Multiple values can be specified. They can be individual email addresses or whole domains.
+
+It is also possible to set the the attributes to map hard coded values if wanted.
+
+### Create an application cliemt
+
+An application can support multiple identity providers.
+
+## Demo Application
+
+With everything set up the demo application in the `site` directory can be run and should be able to be run.
+
+### `.env`
+
+The contents of teh required `.env` file are posted to the screen and can be written to the folder in which the `site` application lives.
+
+### Allow self-signed certificates in dev
+
+It is better to use https for these things, when working in dev `localhost` can be allowed to have self-signed certificates in chrome by setting the flag at `chrome://flags/#allow-insecure-localhost`
+
+### Demo Application
+
+There is a demo application in the `site` folder. It can be run using the command provided.
+
+As the demo app was created using `create-react-app` it can be run using `HTTPS=true PORT=3000 npm start` where `3000` would be replaced with the value entered in teh script.
+
+## Hosted UI Login
+
+Everything can be tested using the Hosted UI.
+
+

--- a/sso/cognito/setup-userpool.sh
+++ b/sso/cognito/setup-userpool.sh
@@ -256,11 +256,16 @@ read -p "Enter a name for the id provider with a maximum of 32 chars. ($DEFAULT_
 ID_PROVIDER_NAME=${INPUT:-$DEFAULT_ID_PROVIDER_NAME}
 echo
 
+echo "Enter the identifiers this identity provide will be used for separated "
+read -p "with spaces. Identifiers can be domains or email addresses." IDENTIFIERS
+echo
+
 echo Creating identity provider $ID_PROVIDER_NAME.
 aws cognito-idp create-identity-provider \
     --user-pool-id $POOL_ID \
     --provider-name=$ID_PROVIDER_NAME \
     --provider-type SAML \
+    --idp-identifiers $IDENTIFIERS \
     --provider-details MetadataURL=$APP_FEDERATION_METADATA_URL \
     --attribute-mapping email=$MAIL_CLAIM_NAME,custom:$GROUPS_ATTRIBUTE=$GROUP_CLAIM_NAME > create-identity-provider.json
 echo Created identity provider $ID_PROVIDER_NAME

--- a/sso/cognito/setup-userpool.sh
+++ b/sso/cognito/setup-userpool.sh
@@ -102,6 +102,17 @@ aws cognito-idp create-user-pool-domain --domain $DOMAIN_PREFIX --user-pool-id $
 echo Created User Pool Domain
 echo
 
+read -p "Enter a name for the groups attribute in cognito which will store the azure groups: ($DEFAULT_GROUPS_ATTRIBUTE) " INPUT
+GROUPS_ATTRIBUTE=${INPUT:-$DEFAULT_GROUPS_ATTRIBUTE}
+echo
+
+echo Adding groups attribute $GROUPS_ATTRIBUTE to pool: $POOL_ID
+aws cognito-idp add-custom-attributes \
+    --user-pool-id $POOL_ID \
+    --custom-attributes Name=$GROUPS_ATTRIBUTE,AttributeDataType="String"
+echo Added groups attribute $GROUPS_ATTRIBUTE to pool: $POOL_ID
+echo
+
 echo Assigning variables for future use:
 ENTITY_ID=urn:amazon:cognito:sp:$POOL_ID
 OAUTH_DOMAIN=$DOMAIN_PREFIX.auth.$AWS_REGION_DEFAULT.amazoncognito.com
@@ -240,17 +251,6 @@ read
 echo Click Assign
 read
 
-read -p "Enter a name for the groups attribute in cognito which will store the azure groups: ($DEFAULT_GROUPS_ATTRIBUTE) " INPUT
-GROUPS_ATTRIBUTE=${INPUT:-$DEFAULT_GROUPS_ATTRIBUTE}
-echo
-
-echo Adding groups attribute $GROUPS_ATTRIBUTE to pool: $POOL_ID
-aws cognito-idp add-custom-attributes \
-    --user-pool-id $POOL_ID \
-    --custom-attributes Name=$GROUPS_ATTRIBUTE,AttributeDataType="String"
-echo Added groups attribute $GROUPS_ATTRIBUTE to pool: $POOL_ID
-echo
-
 DEFAULT_ID_PROVIDER_NAME=azure-${IDENTIFIER}
 read -p "Enter a name for the id provider with a maximum of 32 chars. ($DEFAULT_ID_PROVIDER_NAME) " INPUT
 ID_PROVIDER_NAME=${INPUT:-$DEFAULT_ID_PROVIDER_NAME}
@@ -314,6 +314,32 @@ urlencode() {
 }
 
 if [ -n "$CHOSEN_PORT" ]; then
+
+    echo "To run the example site app with all of the above configured place the following in a .env file in the root of the site directory."
+    echo
+    echo REACT_APP_USERPOOL_ID=$POOL_ID
+    echo REACT_APP_CLIENT_ID=$CLIENT_ID
+    echo REACT_APP_REGION=$AWS_REGION_DEFAULT
+    echo REACT_APP_OAUTH_DOMAIN=$OAUTH_DOMAIN
+    echo REACT_APP_OAUTH_CALLBACK_URL=$CALLBACK_URL
+    echo REACT_APP_OAUTH_SIGNOUT_URL=https://www.google.com/
+    echo REACT_APP_OAUTH_SCOPE=email,openid
+    echo REACT_APP_OAUTH_RESPONSE_TYPE=code
+
+    TARGET_ENV_FILE=$PARENT_DIR/site/.env
+    read -p "Would you like to have this file written to $TARGET_ENV_FILE? (y/n) " INPUT
+    if [ "$INPUT" == "y" ]; then
+        echo REACT_APP_USERPOOL_ID=$POOL_ID > $TARGET_ENV_FILE
+        echo REACT_APP_CLIENT_ID=$CLIENT_ID >> $TARGET_ENV_FILE
+        echo REACT_APP_REGION=$AWS_REGION_DEFAULT >> $TARGET_ENV_FILE
+        echo REACT_APP_OAUTH_DOMAIN=$OAUTH_DOMAIN >> $TARGET_ENV_FILE
+        echo REACT_APP_OAUTH_CALLBACK_URL=$CALLBACK_URL >> $TARGET_ENV_FILE
+        echo REACT_APP_OAUTH_SIGNOUT_URL=https://www.google.com/ >> $TARGET_ENV_FILE
+        echo REACT_APP_OAUTH_SCOPE=email,openid >> $TARGET_ENV_FILE
+        echo REACT_APP_OAUTH_RESPONSE_TYPE=code >> $TARGET_ENV_FILE
+    fi
+    echo
+
     echo When using react locally https with a self signed certificate can be used with the following command: 
     echo
     echo HTTPS=true PORT=$CHOSEN_PORT npm start
@@ -367,27 +393,3 @@ curl -X POST -H "Content-Type: application/x-www-form-urlencoded" \
 echo
 
 
-echo "To run the example site app with all of the above configured place the following in a .env file in the root of the site directory."
-echo
-echo REACT_APP_USERPOOL_ID=$POOL_ID
-echo REACT_APP_CLIENT_ID=$CLIENT_ID
-echo REACT_APP_REGION=$AWS_REGION_DEFAULT
-echo REACT_APP_OAUTH_DOMAIN=$OAUTH_DOMAIN
-echo REACT_APP_OAUTH_CALLBACK_URL=$CALLBACK_URL
-echo REACT_APP_OAUTH_SIGNOUT_URL=https://www.google.com/
-echo REACT_APP_OAUTH_SCOPE=email,openid
-echo REACT_APP_OAUTH_RESPONSE_TYPE=code
-
-TARGET_ENV_FILE=$PARENT_DIR/site/.env
-read -p "Would you like to have this file written to $TARGET_ENV_FILE? (y/n) " INPUT
-if [ "$INPUT" == "y" ]; then
-    echo REACT_APP_USERPOOL_ID=$POOL_ID > $TARGET_ENV_FILE
-    echo REACT_APP_CLIENT_ID=$CLIENT_ID >> $TARGET_ENV_FILE
-    echo REACT_APP_REGION=$AWS_REGION_DEFAULT >> $TARGET_ENV_FILE
-    echo REACT_APP_OAUTH_DOMAIN=$OAUTH_DOMAIN >> $TARGET_ENV_FILE
-    echo REACT_APP_OAUTH_CALLBACK_URL=$CALLBACK_URL >> $TARGET_ENV_FILE
-    echo REACT_APP_OAUTH_SIGNOUT_URL=https://www.google.com/ >> $TARGET_ENV_FILE
-    echo REACT_APP_OAUTH_SCOPE=email,openid >> $TARGET_ENV_FILE
-    echo REACT_APP_OAUTH_RESPONSE_TYPE=code >> $TARGET_ENV_FILE
-fi
-echo


### PR DESCRIPTION
Added some instructions that explain how to add support for multiple identity providers.

This allows for multiple Azure AD instances to be connected to the same application.

Once set up in that way, a box like this will appear on the hosted UI. The value entered will be used to determine which identity provider will be used.

<img width="372" alt="image" src="https://github.com/cactus-bm/examples/assets/2609402/f0fcd862-ed02-4329-81ee-a046a32755c7">
